### PR TITLE
Set update record's response type to None

### DIFF
--- a/authress_sdk/api/access_records_api.py
+++ b/authress_sdk/api/access_records_api.py
@@ -572,7 +572,7 @@ class AccessRecordsApi(object):
             body=body_params,
             post_params=form_params,
             files=local_var_files,
-            response_type='AccessRecord',
+            response_type=None,
             async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),


### PR DESCRIPTION
`authress_client.records.update_record` successfully calls `PUT` request to update access records but raises a ValueError before returning. ValueError is raised because the function is trying to convert the response into an Access Record but `PUT` doesn't return a response body. Changing the response type to `None` fixes this issue.