### PR TITLE
Remove version conflict with usage of pydantic v2. fix #15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the changelog for [Authress SDK](readme.md).
 * [Breaking] Renamed `AccessRecordResource` model to `Resource` in `models.resource.py`.
 * Add missing `If-Unmodified-Since` support to the `update_group` in the `Groups` API.
 * Improve caching in `verify_token`
+* Support additionally pydantic v2 dependencies. Support for v1 will be removed in a future version.
 
 ## 2.0 ##
 * Add support for users and groups at the statement level of access records.

--- a/authress/api/access_records_api.py
+++ b/authress/api/access_records_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr, conint, constr, validator
+try:
+    from pydantic.v1 import Field, StrictStr, conint, constr, validator
+except ImportError:
+    from pydantic import Field, StrictStr, conint, constr, validator
 
 from typing import Any, Dict, Optional
 

--- a/authress/api/accounts_api.py
+++ b/authress/api/accounts_api.py
@@ -17,12 +17,18 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError, constr
+try:
+    from pydantic.v1 import validate_arguments, ValidationError, constr
+except ImportError:
+    from pydantic import validate_arguments, ValidationError, constr
 from typing_extensions import Annotated
 
 from datetime import datetime
 
-from pydantic import Field, StrictStr
+try:
+    from pydantic.v1 import Field, StrictStr
+except ImportError:
+    from pydantic import Field, StrictStr
 
 from typing import Optional
 

--- a/authress/api/applications_api.py
+++ b/authress/api/applications_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, constr
+try:
+    from pydantic.v1 import Field, constr
+except ImportError:
+    from pydantic import Field, constr
 
 from authress.models.application_delegation import ApplicationDelegation
 

--- a/authress/api/connections_api.py
+++ b/authress/api/connections_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, constr
+try:
+    from pydantic.v1 import Field, constr
+except ImportError:
+    from pydantic import Field, constr
 
 from authress.models.connection import Connection
 from authress.models.connection_collection import ConnectionCollection

--- a/authress/api/extensions_api.py
+++ b/authress/api/extensions_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr, constr
+try:
+    from pydantic.v1 import Field, StrictStr, constr
+except ImportError:
+    from pydantic import Field, StrictStr, constr
 
 from typing import Optional
 

--- a/authress/api/groups_api.py
+++ b/authress/api/groups_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr, conint, constr
+try:
+    from pydantic.v1 import Field, StrictStr, conint, constr
+except ImportError:
+    from pydantic import Field, StrictStr, conint, constr
 
 from typing import Optional
 

--- a/authress/api/invites_api.py
+++ b/authress/api/invites_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, constr
+try:
+    from pydantic.v1 import Field, constr
+except ImportError:
+    from pydantic import Field, constr
 
 from authress.models.account import Account
 from authress.models.invite import Invite

--- a/authress/api/resource_permissions_api.py
+++ b/authress/api/resource_permissions_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr, conint, constr, validator
+try:
+    from pydantic.v1 import Field, StrictStr, conint, constr, validator
+except ImportError:
+    from pydantic import Field, StrictStr, conint, constr, validator
 
 from typing import Optional
 

--- a/authress/api/roles_api.py
+++ b/authress/api/roles_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, constr, validator
+try:
+    from pydantic.v1 import Field, constr, validator
+except ImportError:
+    from pydantic import Field, constr, validator
 
 from authress.models.role import Role
 from authress.models.role_collection import RoleCollection

--- a/authress/api/service_clients_api.py
+++ b/authress/api/service_clients_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr, conint, constr
+try:
+    from pydantic.v1 import Field, StrictStr, conint, constr
+except ImportError:
+    from pydantic import Field, StrictStr, conint, constr
 
 from typing import Optional
 

--- a/authress/api/tenants_api.py
+++ b/authress/api/tenants_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError, constr
+try:
+    from pydantic.v1 import validate_arguments, ValidationError, constr
+except ImportError:
+    from pydantic import validate_arguments, ValidationError, constr
 from typing_extensions import Annotated
 
-from pydantic import Field
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 from authress.models.tenant import Tenant
 from authress.models.tenant_collection import TenantCollection

--- a/authress/api/user_permissions_api.py
+++ b/authress/api/user_permissions_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr, conint, constr, validator
+try:
+    from pydantic.v1 import Field, StrictStr, conint, constr, validator
+except ImportError:
+    from pydantic import Field, StrictStr, conint, constr, validator
 
 from typing import Optional
 

--- a/authress/api/users_api.py
+++ b/authress/api/users_api.py
@@ -17,10 +17,16 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr, conint, constr
+try:
+    from pydantic.v1 import Field, StrictStr, conint, constr
+except ImportError:
+    from pydantic import Field, StrictStr, conint, constr
 
 from typing import Optional
 

--- a/authress/api_response.py
+++ b/authress/api_response.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+try:
+    from pydantic.v1 import Field, StrictInt, StrictStr
+except ImportError:
+    from pydantic import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/authress/models/access_record.py
+++ b/authress/models/access_record.py
@@ -20,7 +20,10 @@ import json
 
 from datetime import datetime
 from typing import Dict, List, Optional, Union
-from pydantic import BaseModel, Field, StrictStr, confloat, conint, conlist, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, confloat, conint, conlist, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, confloat, conint, conlist, constr, validator
 from authress.models.access_record_account import AccessRecordAccount
 from authress.models.account_links import AccountLinks
 from authress.models.linked_group import LinkedGroup

--- a/authress/models/access_record_account.py
+++ b/authress/models/access_record_account.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class AccessRecordAccount(BaseModel):
     """

--- a/authress/models/access_record_collection.py
+++ b/authress/models/access_record_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.access_record import AccessRecord
 from authress.models.collection_links import CollectionLinks
 from authress.models.pagination import Pagination

--- a/authress/models/access_request.py
+++ b/authress/models/access_request.py
@@ -20,7 +20,10 @@ import json
 
 from datetime import datetime
 from typing import Dict, Optional
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
 from authress.models.access_template import AccessTemplate
 from authress.models.account_links import AccountLinks
 

--- a/authress/models/access_request_collection.py
+++ b/authress/models/access_request_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.access_request import AccessRequest
 from authress.models.collection_links import CollectionLinks
 from authress.models.pagination import Pagination

--- a/authress/models/access_request_response.py
+++ b/authress/models/access_request_response.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, validator
 
 class AccessRequestResponse(BaseModel):
     """

--- a/authress/models/access_template.py
+++ b/authress/models/access_template.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.statement import Statement
 from authress.models.user import User
 

--- a/authress/models/account.py
+++ b/authress/models/account.py
@@ -20,7 +20,10 @@ import json
 
 from datetime import datetime
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field, constr
+try:
+    from pydantic.v1 import BaseModel, Field, constr
+except ImportError:
+    from pydantic import BaseModel, Field, constr
 from authress.models.account_links import AccountLinks
 
 class Account(BaseModel):

--- a/authress/models/account_collection.py
+++ b/authress/models/account_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field
+try:
+    from pydantic.v1 import BaseModel, Field
+except ImportError:
+    from pydantic import BaseModel, Field
 from authress.models.account import Account
 
 class AccountCollection(BaseModel):

--- a/authress/models/account_links.py
+++ b/authress/models/account_links.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field
+try:
+    from pydantic.v1 import BaseModel, Field
+except ImportError:
+    from pydantic import BaseModel, Field
 from authress.models.link import Link
 
 class AccountLinks(BaseModel):

--- a/authress/models/application_delegation.py
+++ b/authress/models/application_delegation.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class ApplicationDelegation(BaseModel):
     """

--- a/authress/models/claim_request.py
+++ b/authress/models/claim_request.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, constr
+try:
+    from pydantic.v1 import BaseModel, Field, constr
+except ImportError:
+    from pydantic import BaseModel, Field, constr
 
 class ClaimRequest(BaseModel):
     """

--- a/authress/models/client.py
+++ b/authress/models/client.py
@@ -20,7 +20,10 @@ import json
 
 from datetime import datetime
 from typing import Dict, List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist, constr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, conlist, constr
 from authress.models.client_access_key import ClientAccessKey
 from authress.models.client_options import ClientOptions
 

--- a/authress/models/client_access_key.py
+++ b/authress/models/client_access_key.py
@@ -20,7 +20,10 @@ import json
 
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class ClientAccessKey(BaseModel):
     """

--- a/authress/models/client_collection.py
+++ b/authress/models/client_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.client import Client
 from authress.models.collection_links import CollectionLinks
 from authress.models.pagination import Pagination

--- a/authress/models/client_options.py
+++ b/authress/models/client_options.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool
+try:
+    from pydantic.v1 import BaseModel, Field, StrictBool
+except ImportError:
+    from pydantic import BaseModel, Field, StrictBool
 
 class ClientOptions(BaseModel):
     """

--- a/authress/models/collection_links.py
+++ b/authress/models/collection_links.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field
+try:
+    from pydantic.v1 import BaseModel, Field
+except ImportError:
+    from pydantic import BaseModel, Field
 from authress.models.link import Link
 
 class CollectionLinks(BaseModel):

--- a/authress/models/connection.py
+++ b/authress/models/connection.py
@@ -20,7 +20,10 @@ import json
 
 from datetime import datetime
 from typing import Dict, Optional
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
 from authress.models.connection_data import ConnectionData
 from authress.models.connection_default_connection_properties import ConnectionDefaultConnectionProperties
 

--- a/authress/models/connection_collection.py
+++ b/authress/models/connection_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.connection import Connection
 from authress.models.pagination import Pagination
 

--- a/authress/models/connection_data.py
+++ b/authress/models/connection_data.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
 
 class ConnectionData(BaseModel):
     """

--- a/authress/models/connection_default_connection_properties.py
+++ b/authress/models/connection_default_connection_properties.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, constr
+try:
+    from pydantic.v1 import BaseModel, constr
+except ImportError:
+    from pydantic import BaseModel, constr
 
 class ConnectionDefaultConnectionProperties(BaseModel):
     """

--- a/authress/models/extension.py
+++ b/authress/models/extension.py
@@ -20,7 +20,10 @@ import json
 
 from datetime import datetime
 from typing import Dict, Optional
-from pydantic import BaseModel, Field, constr
+try:
+    from pydantic.v1 import BaseModel, Field, constr
+except ImportError:
+    from pydantic import BaseModel, Field, constr
 from authress.models.extension_application import ExtensionApplication
 from authress.models.extension_client import ExtensionClient
 

--- a/authress/models/extension_application.py
+++ b/authress/models/extension_application.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist, constr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, conlist, constr
 from authress.models.links import Links
 
 class ExtensionApplication(BaseModel):

--- a/authress/models/extension_client.py
+++ b/authress/models/extension_client.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 from authress.models.links import Links
 
 class ExtensionClient(BaseModel):

--- a/authress/models/extension_collection.py
+++ b/authress/models/extension_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.extension import Extension
 from authress.models.pagination import Pagination
 

--- a/authress/models/group.py
+++ b/authress/models/group.py
@@ -20,7 +20,10 @@ import json
 
 from datetime import datetime
 from typing import Dict, List, Optional
-from pydantic import BaseModel, Field, conlist, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, conlist, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, conlist, constr, validator
 from authress.models.account_links import AccountLinks
 from authress.models.user import User
 

--- a/authress/models/group_collection.py
+++ b/authress/models/group_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.collection_links import CollectionLinks
 from authress.models.group import Group
 from authress.models.pagination import Pagination

--- a/authress/models/identity.py
+++ b/authress/models/identity.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class Identity(BaseModel):
     """

--- a/authress/models/identity_collection.py
+++ b/authress/models/identity_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.identity import Identity
 
 class IdentityCollection(BaseModel):

--- a/authress/models/identity_request.py
+++ b/authress/models/identity_request.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class IdentityRequest(BaseModel):
     """

--- a/authress/models/invite.py
+++ b/authress/models/invite.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist, constr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, conlist, constr
 from authress.models.account_links import AccountLinks
 from authress.models.statement import Statement
 

--- a/authress/models/link.py
+++ b/authress/models/link.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class Link(BaseModel):
     """

--- a/authress/models/linked_group.py
+++ b/authress/models/linked_group.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class LinkedGroup(BaseModel):
     """

--- a/authress/models/links.py
+++ b/authress/models/links.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field
+try:
+    from pydantic.v1 import BaseModel, Field
+except ImportError:
+    from pydantic import BaseModel, Field
 from authress.models.link import Link
 
 class Links(BaseModel):

--- a/authress/models/metadata_object.py
+++ b/authress/models/metadata_object.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 from authress.models.metadata_object_account import MetadataObjectAccount
 
 class MetadataObject(BaseModel):

--- a/authress/models/metadata_object_account.py
+++ b/authress/models/metadata_object_account.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class MetadataObjectAccount(BaseModel):
     """

--- a/authress/models/o_auth_authorize_response.py
+++ b/authress/models/o_auth_authorize_response.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class OAuthAuthorizeResponse(BaseModel):
     """

--- a/authress/models/o_auth_token_request.py
+++ b/authress/models/o_auth_token_request.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, validator
 
 class OAuthTokenRequest(BaseModel):
     """

--- a/authress/models/o_auth_token_response.py
+++ b/authress/models/o_auth_token_response.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class OAuthTokenResponse(BaseModel):
     """

--- a/authress/models/pagination.py
+++ b/authress/models/pagination.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 from authress.models.pagination_next import PaginationNext
 
 class Pagination(BaseModel):

--- a/authress/models/pagination_next.py
+++ b/authress/models/pagination_next.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class PaginationNext(BaseModel):
     """

--- a/authress/models/permission_collection.py
+++ b/authress/models/permission_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, conlist
 from authress.models.permission_collection_account import PermissionCollectionAccount
 from authress.models.permission_object import PermissionObject
 

--- a/authress/models/permission_collection_account.py
+++ b/authress/models/permission_collection_account.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class PermissionCollectionAccount(BaseModel):
     """

--- a/authress/models/permission_object.py
+++ b/authress/models/permission_object.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictBool, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, StrictBool, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, StrictBool, constr, validator
 
 class PermissionObject(BaseModel):
     """

--- a/authress/models/permissioned_resource.py
+++ b/authress/models/permissioned_resource.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.resource_permission import ResourcePermission
 
 class PermissionedResource(BaseModel):

--- a/authress/models/permissioned_resource_collection.py
+++ b/authress/models/permissioned_resource_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.collection_links import CollectionLinks
 from authress.models.pagination import Pagination
 from authress.models.permissioned_resource import PermissionedResource

--- a/authress/models/resource.py
+++ b/authress/models/resource.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, constr, validator
 
 class Resource(BaseModel):
     """

--- a/authress/models/resource_permission.py
+++ b/authress/models/resource_permission.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictBool, StrictStr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, validator
 
 class ResourcePermission(BaseModel):
     """

--- a/authress/models/resource_users_collection.py
+++ b/authress/models/resource_users_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.collection_links import CollectionLinks
 from authress.models.pagination import Pagination
 from authress.models.user_role_collection import UserRoleCollection

--- a/authress/models/role.py
+++ b/authress/models/role.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, conlist, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, conlist, constr, validator
 from authress.models.permission_object import PermissionObject
 
 class Role(BaseModel):

--- a/authress/models/role_collection.py
+++ b/authress/models/role_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.collection_links import CollectionLinks
 from authress.models.pagination import Pagination
 from authress.models.role import Role

--- a/authress/models/statement.py
+++ b/authress/models/statement.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, conlist, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, conlist, constr, validator
 from authress.models.linked_group import LinkedGroup
 from authress.models.resource import Resource
 from authress.models.user import User

--- a/authress/models/tenant.py
+++ b/authress/models/tenant.py
@@ -20,7 +20,10 @@ import json
 
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, constr, validator
 from authress.models.tenant_connection import TenantConnection
 from authress.models.tenant_data import TenantData
 

--- a/authress/models/tenant_collection.py
+++ b/authress/models/tenant_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.pagination import Pagination
 from authress.models.tenant import Tenant
 

--- a/authress/models/tenant_connection.py
+++ b/authress/models/tenant_connection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, constr, validator
 
 class TenantConnection(BaseModel):
     """

--- a/authress/models/tenant_data.py
+++ b/authress/models/tenant_data.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, constr
+try:
+    from pydantic.v1 import BaseModel, constr
+except ImportError:
+    from pydantic import BaseModel, constr
 
 class TenantData(BaseModel):
     """

--- a/authress/models/token_request.py
+++ b/authress/models/token_request.py
@@ -20,7 +20,10 @@ import json
 
 from datetime import datetime
 from typing import List
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.statement import Statement
 
 class TokenRequest(BaseModel):

--- a/authress/models/user.py
+++ b/authress/models/user.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, constr, validator
 
 class User(BaseModel):
     """

--- a/authress/models/user_connection_credentials.py
+++ b/authress/models/user_connection_credentials.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class UserConnectionCredentials(BaseModel):
     """

--- a/authress/models/user_identity.py
+++ b/authress/models/user_identity.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class UserIdentity(BaseModel):
     """

--- a/authress/models/user_identity_collection.py
+++ b/authress/models/user_identity_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, conlist
 from authress.models.collection_links import CollectionLinks
 from authress.models.pagination import Pagination
 from authress.models.user_identity import UserIdentity

--- a/authress/models/user_resources_collection.py
+++ b/authress/models/user_resources_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, conlist
 from authress.models.collection_links import CollectionLinks
 from authress.models.pagination import Pagination
 from authress.models.permission_collection_account import PermissionCollectionAccount

--- a/authress/models/user_role.py
+++ b/authress/models/user_role.py
@@ -20,7 +20,10 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 
 class UserRole(BaseModel):
     """

--- a/authress/models/user_role_collection.py
+++ b/authress/models/user_role_collection.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, StrictStr, conlist
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, conlist
 from authress.models.user_role import UserRole
 
 class UserRoleCollection(BaseModel):

--- a/authress/models/user_token.py
+++ b/authress/models/user_token.py
@@ -20,7 +20,10 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 from authress.models.account_links import AccountLinks
 from authress.models.permission_collection_account import PermissionCollectionAccount
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.7"
 
 urllib3 = ">= 1.25.3"
 python-dateutil = ">=2.8.2"
-pydantic = "^1.10.5, <2"
+pydantic = "^1.10.5, <3"
 aenum = ">=3.1.11"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
 PyJWT >= 2.4.0
 cryptography >= 2.9.2
-pydantic >= 1.10.5, < 2
+pydantic >= 1.10.5, < 3
 aenum >= 3.1.11

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 REQUIRES = [
   "urllib3 >= 1.25.3, < 2.1.0",
   "python-dateutil",
-  "pydantic >= 1.10.5, < 2",
+  "pydantic >= 1.10.5, < 3",
   "aenum"
 ]
 


### PR DESCRIPTION
Imports are optimized to support pydantic v2 but gracefully falls back to v1:
```py
try:
    from pydantic.v1 import validate_arguments, ValidationError
except ImportError:
    from pydantic import validate_arguments, ValidationError
```