### PR TITLE
Prevent trailing slashes in url.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the changelog for [Authress SDK](readme.md).
 * Add missing `If-Unmodified-Since` support to the `update_group` in the `Groups` API.
 * Improve caching in `verify_token`
 * Support additionally pydantic v2 dependencies. Support for v1 will be removed in a future version.
+* Prevent unnecessary extra trailing slashes in domain name.
 
 ## 2.0 ##
 * Add support for users and groups at the statement level of access records.

--- a/authress/authress_client.py
+++ b/authress/authress_client.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import
 
 import json
+import re
+
 from authress.api.applications_api import ApplicationsApi
 from authress.api.connections_api import ConnectionsApi
 from authress.api.extensions_api import ExtensionsApi
@@ -23,6 +25,7 @@ from authress.api import token_verifier
 class AuthressClient(object):
     def __init__(self, authress_api_url=None, service_client_access_key=None):
         self._host = authress_api_url if authress_api_url.startswith('http') else f"https://{authress_api_url}"
+        self._host = re.sub(r'/+$', '', self._host)
         self._token_verifier = token_verifier.TokenVerifier()
         self._http_client = HttpClient(host=self._host, access_key=service_client_access_key)
 


### PR DESCRIPTION
Fixing:
```
404 Path Not Found: GET //v1/tenants - Authress SDK; Python; 3.0.76;
```