### PR TITLE
chore: updates urllib3 constraints to "<= 2.2.2"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 REQUIRES = [
-  "urllib3 >= 1.25.3, < 2.1.0",
+  "urllib3 >= 1.25.3, <= 2.2.2",
   "python-dateutil",
   "pydantic >= 1.10.5, < 3",
   "PyJWT >= 2.4.0",


### PR DESCRIPTION
## Description

Many Python libraries depend on newer versions of `urllib3`, thus the `< 2.1.0` constraint breaks dependency resolution when using authress together with other Python libraries.

Given the 2.1.0 -> 2.2.2 [urllib changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) does not include breaking changes to the Authress SDK, I propose the upper bound for urllib is bumped to `<= 2.2.2` (latest)